### PR TITLE
Test for callback before calling it in recogniser.stop()

### DIFF
--- a/BingSpeechService.js
+++ b/BingSpeechService.js
@@ -204,7 +204,7 @@ BingSpeechService.prototype.start = function(callback) {
 };
 
 BingSpeechService.prototype.stop = function(callback) {
-    if (!this.connection || !this.connection.connected) return callback(null);
+    if ((!this.connection || !this.connection.connected) && callback) return callback(null);
     if (callback) this.connection.once('close', callback);
     this.connection.close();
     debug('closed speech websocket connection');


### PR DESCRIPTION
Prevents
```
/app/node_modules/ms-bing-speech-service/BingSpeechService.js:207
    if (!this.connection || !this.connection.connected) return callback(null);
                                                               ^
TypeError: callback is not a function
```

Have a nice day 🌤