### PR TITLE
Send zero-length audio message to signal end of audio stream

### DIFF
--- a/BingSpeechService.js
+++ b/BingSpeechService.js
@@ -83,6 +83,10 @@ module.exports = function (dependencies) {
         inputStream.on('data', this.sendChunk.bind(this));
 
         inputStream.on('end', () => {
+          // To signal end-of-speech, client applications send an audio chunk message with a zero-length body.
+          // Speech Service interprets this message as the end of the incoming audio stream.
+          // PER https://docs.microsoft.com/en-us/azure/cognitive-services/speech/api-reference-rest/websocketprotocol#client-end-of-speech-detection
+          this.sendChunk('');
           debug('audio stream end');
           resolve();
         });


### PR DESCRIPTION
Fix #24 

To signal end-of-speech, client applications send an audio chunk message with a zero-length body.
Speech Service interprets this message as the end of the incoming audio stream.

SEE https://docs.microsoft.com/en-us/azure/cognitive-services/speech/api-reference-rest/websocketprotocol#client-end-of-speech-detection