### PR TITLE
Fixed Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ recognizer
     recognizer.sendFile('future-of-flying.wav')
       .then(_ => console.log('file sent.'))
       .catch(console.error);
-  }
-}).catch(console.error);
+  })
+  .catch(console.error);
 
 ```
 


### PR DESCRIPTION
Remove an extra closing brace in first code example.  If a user was copy/pasting the code (like me 😄), it had a syntax error.